### PR TITLE
add anchor shortcuts to headings in s-read-md

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -74,6 +74,7 @@ gulp.task('build', ['src:symlink-repos', "js:copy-vendor"], done => {
         "js/syntaxHighlight.js",
         "js/endpointRef.js",
         "js/friendbot4.js",
+        "js/headingAnchorShortcut.js",
         "js/linkCheck.js",
       ],
       output: "js/app.js",

--- a/src/js/headingAnchorShortcut.js
+++ b/src/js/headingAnchorShortcut.js
@@ -1,0 +1,8 @@
+// This adds functionality to all headers inside s-read-md to have a # appear on
+// hover so that it is easier to link to specific parts of the article
+$('s-read-md h1, s-read-md h2, s-read-md h3, s-read-md h4, s-read-md h5, s-read-md h6').each(function(i, elem) {
+  'use strict';
+  if (elem.id !== '') {
+    $(elem).prepend('<a class="anchorShortcut" href="#' + elem.id + '"></a>');
+  }
+});

--- a/src/styles/_anchorShortcut.scss
+++ b/src/styles/_anchorShortcut.scss
@@ -1,0 +1,25 @@
+// Anchor shortcuts only apply on headings (h1, h2, h3, h4, h5, h6)
+.anchorShortcut {
+  position: relative;
+}
+.anchorShortcut:before {
+  display: inline-block;
+  content: '#';
+  position: absolute;
+  right: 0;
+
+  padding: 0 .25em;
+  opacity: 0;
+  color: $s-color-neutral7;
+}
+.anchorShortcut:hover:before {
+  color: $s-color-primary4;
+}
+h1:hover > .anchorShortcut:before,
+h2:hover > .anchorShortcut:before,
+h3:hover > .anchorShortcut:before,
+h4:hover > .anchorShortcut:before,
+h5:hover > .anchorShortcut:before,
+h6:hover > .anchorShortcut:before {
+  opacity: 1;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -10,6 +10,7 @@
 @import 'mailSignup';
 @import 'graphics';
 @import 'backgrounds';
+@import 'anchorShortcut';
 
 @import 'siteFooter';
 


### PR DESCRIPTION
Looks something like this when hovered:

![image](https://cloud.githubusercontent.com/assets/5728307/12902785/2a5d5360-ce78-11e5-8488-20e3b2464a94.png)

Implements https://github.com/stellar/developers/issues/38