### PR TITLE
Header and sidebar amendments

### DIFF
--- a/gulp/handlebars.js
+++ b/gulp/handlebars.js
@@ -36,9 +36,9 @@ module.exports.helpers = {
 
   sidebarSubMenu(title, options) {
     return `
-      <li class="pageNavList__subList">
-        <span class="pageNavList__title">${title}</span>
-        <ul>
+      <li class="pageNavList__subList collapsibleListSet js-collapsibleListSet">
+        <span class="pageNavList__title collapsibleListSet__label js-collapsibleListSet__label">${title}</span>
+        <ul class="collapsibleListSet__list js-collapsibleListSet__list is-collapsed">
           ${options.fn(this)}
         </ul>
       </li>

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -74,6 +74,7 @@ gulp.task('build', ['src:symlink-repos', "js:copy-vendor"], done => {
         "js/syntaxHighlight.js",
         "js/endpointRef.js",
         "js/friendbot4.js",
+        "js/collapsibleListSet.js",
         "js/headingAnchorShortcut.js",
         "js/linkCheck.js",
       ],

--- a/layouts/beyond-code.handlebars
+++ b/layouts/beyond-code.handlebars
@@ -1,4 +1,5 @@
 {{> head }}
+{{> header-full-with-sidebar }}
 
 <div class="S-flex-row">
   {{> beyond-code/sidebar }}

--- a/layouts/learn.handlebars
+++ b/layouts/learn.handlebars
@@ -1,4 +1,5 @@
 {{> head }}
+{{> header-full-with-sidebar }}
 
 <div class="S-flex-row">
   {{> learn/sidebar }}

--- a/layouts/reference.handlebars
+++ b/layouts/reference.handlebars
@@ -1,4 +1,5 @@
 {{> head }}
+{{> header-full-with-sidebar }}
 
 <div class="S-flex-row">
   {{> reference/sidebar }}

--- a/layouts/tools.handlebars
+++ b/layouts/tools.handlebars
@@ -1,4 +1,5 @@
 {{> head }}
+{{> header-full-with-sidebar }}
 
 <div class="S-flex-row">
   {{> tools/sidebar }}

--- a/partials/beyond-code/sidebar.handlebars
+++ b/partials/beyond-code/sidebar.handlebars
@@ -1,5 +1,4 @@
 <div class="siteSidebar">
-  <h2 class="mainSectionTitle">Beyond Code</h2>
   <div class="mainSidebar">
     <ul class="pageNavList">
       <li class="pageNavList__item"><a href="{{pathPrefix}}/beyond-code/">Overview</a></li>

--- a/partials/beyond-code/sidebar.handlebars
+++ b/partials/beyond-code/sidebar.handlebars
@@ -1,7 +1,4 @@
 <div class="siteSidebar">
-  <div class="so-siteHeader">
-    {{> siteLogo  }}
-  </div>
   <h2 class="mainSectionTitle">Beyond Code</h2>
   <div class="mainSidebar">
     <ul class="pageNavList">

--- a/partials/beyond-code/sidebar.handlebars
+++ b/partials/beyond-code/sidebar.handlebars
@@ -1,4 +1,4 @@
-<div class="siteSidebar">
+<div class="siteSidebar pageNavListBounder">
   <div class="mainSidebar">
     <ul class="pageNavList">
       <li class="pageNavList__item"><a href="{{pathPrefix}}/beyond-code/">Overview</a></li>

--- a/partials/contentWrapperStart.handlebars
+++ b/partials/contentWrapperStart.handlebars
@@ -1,10 +1,4 @@
 <div class="S-flexItem-share">
-  <div class="so-siteHeader spu-padStart-30">
-    <div class="so-siteHeader__emptyLogo"></div>
-    <nav class="s-inlineList s-inlineList--wide so-siteHeader__navList so-siteHeader__simpleAlign">
-      {{> mainNavMenu }}
-    </nav>
-  </div>
   <div class="spu-padSE-30">
     <h1 class="mainSectionTitle">
       {{ title }}

--- a/partials/header-centered.handlebars
+++ b/partials/header-centered.handlebars
@@ -1,0 +1,10 @@
+<div class="so-back">
+  <div class="so-chunk">
+    <div class="so-siteHeader">
+      {{> siteLogo }}
+        <nav class="s-inlineList s-inlineList--wide so-siteHeader__navList spu-padStart-30 so-siteHeader__simpleAlign">
+          {{> mainNavMenu }}
+        </nav>
+    </div>
+  </div>
+</div>

--- a/partials/header-centered.handlebars
+++ b/partials/header-centered.handlebars
@@ -1,10 +1,14 @@
 <div class="so-back">
   <div class="so-chunk">
-    <div class="so-siteHeader">
-      {{> siteLogo }}
-        <nav class="s-inlineList s-inlineList--wide so-siteHeader__navList spu-padStart-30 so-siteHeader__simpleAlign">
-          {{> mainNavMenu }}
-        </nav>
+    <div class="header2016">
+      <div class="header2016__logo">
+        <div class="so-siteHeader">
+          {{> siteLogo }}
+        </div>
+      </div>
+      <nav class="header2016__nav mainNavMenu spu-padStart-30">
+        {{> mainNavMenu }}
+      </nav>
     </div>
   </div>
 </div>

--- a/partials/header-full-with-sidebar.handlebars
+++ b/partials/header-full-with-sidebar.handlebars
@@ -1,0 +1,10 @@
+<div class="so-siteHeader headerWithSidebar">
+  <div class="headerWithSidebar__logo">
+    {{> siteLogo }}
+  </div>
+  <div class="headerWithSidebar__nav">
+    <nav class="s-inlineList s-inlineList--wide so-siteHeader__navList spu-padStart-30 so-siteHeader__simpleAlign">
+      {{> mainNavMenu }}
+    </nav>
+  </div>
+</div>

--- a/partials/header-full-with-sidebar.handlebars
+++ b/partials/header-full-with-sidebar.handlebars
@@ -1,10 +1,10 @@
-<div class="so-siteHeader headerWithSidebar">
+<div class="headerWithSidebar">
   <div class="headerWithSidebar__logo">
-    {{> siteLogo }}
+    <div class="so-siteHeader">
+      {{> siteLogo }}
+    </div>
   </div>
-  <div class="headerWithSidebar__nav">
-    <nav class="s-inlineList s-inlineList--wide so-siteHeader__navList spu-padStart-30 so-siteHeader__simpleAlign">
+    <nav class="headerWithSidebar__nav mainNavMenu spu-padStart-30">
       {{> mainNavMenu }}
     </nav>
-  </div>
 </div>

--- a/partials/header-full-with-sidebar.handlebars
+++ b/partials/header-full-with-sidebar.handlebars
@@ -1,10 +1,10 @@
-<div class="headerWithSidebar">
-  <div class="headerWithSidebar__logo">
+<div class="header2016">
+  <div class="header2016__logo header2016__logo--spaced">
     <div class="so-siteHeader">
       {{> siteLogo }}
     </div>
   </div>
-    <nav class="headerWithSidebar__nav mainNavMenu spu-padStart-30">
-      {{> mainNavMenu }}
-    </nav>
+  <nav class="header2016__nav mainNavMenu spu-padStart-30">
+    {{> mainNavMenu }}
+  </nav>
 </div>

--- a/partials/learn/sidebar.handlebars
+++ b/partials/learn/sidebar.handlebars
@@ -1,7 +1,4 @@
 <div class="siteSidebar">
-  <div class="so-siteHeader">
-    {{> siteLogo  }}
-  </div>
   <h2 class="mainSectionTitle">Learn</h2>
   <div class="mainSidebar">
     <ul class="pageNavList">

--- a/partials/learn/sidebar.handlebars
+++ b/partials/learn/sidebar.handlebars
@@ -1,4 +1,4 @@
-<div class="siteSidebar">
+<div class="siteSidebar pageNavListBounder">
   <div class="mainSidebar">
     <ul class="pageNavList">
       {{>sidebarSubMenu title="Get Started" glob="learn/get-started/*.html"}}

--- a/partials/learn/sidebar.handlebars
+++ b/partials/learn/sidebar.handlebars
@@ -1,5 +1,4 @@
 <div class="siteSidebar">
-  <h2 class="mainSectionTitle">Learn</h2>
   <div class="mainSidebar">
     <ul class="pageNavList">
       {{>sidebarSubMenu title="Get Started" glob="learn/get-started/*.html"}}

--- a/partials/mainNavMenu/item.handlebars
+++ b/partials/mainNavMenu/item.handlebars
@@ -1,1 +1,1 @@
-<a class="s-inlineList__item so-siteHeader__navList__item {{#equal section sectionFilter}}is-currentItem{{/equal}}" href="{{pathPrefix}}{{href}}">{{text}}</a>
+<a class="mainNavMenu__item {{#equal section sectionFilter}}is-currentItem{{/equal}}" href="{{pathPrefix}}{{href}}">{{text}}</a>

--- a/partials/reference/sidebar.handlebars
+++ b/partials/reference/sidebar.handlebars
@@ -1,5 +1,4 @@
 <div class="siteSidebar">
-  <h2 class="mainSectionTitle">Reference</h2>
   <div class="mainSidebar">
     <ul class="pageNavList">
 

--- a/partials/reference/sidebar.handlebars
+++ b/partials/reference/sidebar.handlebars
@@ -1,7 +1,4 @@
 <div class="siteSidebar">
-  <div class="so-siteHeader">
-    {{> siteLogo  }}
-  </div>
   <h2 class="mainSectionTitle">Reference</h2>
   <div class="mainSidebar">
     <ul class="pageNavList">

--- a/partials/reference/sidebar.handlebars
+++ b/partials/reference/sidebar.handlebars
@@ -1,4 +1,4 @@
-<div class="siteSidebar">
+<div class="siteSidebar pageNavListBounder">
   <div class="mainSidebar">
     <ul class="pageNavList">
 

--- a/partials/tools/sidebar.handlebars
+++ b/partials/tools/sidebar.handlebars
@@ -1,7 +1,4 @@
 <div class="siteSidebar">
-  <div class="so-siteHeader">
-    {{> siteLogo  }}
-  </div>
   <h2 class="mainSectionTitle">Tools</h2>
   <div class="mainSidebar">
     <ul class="pageNavList">

--- a/partials/tools/sidebar.handlebars
+++ b/partials/tools/sidebar.handlebars
@@ -1,4 +1,4 @@
-<div class="siteSidebar">
+<div class="siteSidebar pageNavListBounder">
   <div class="mainSidebar">
     <ul class="pageNavList">
       <li class="pageNavList__item"><a href="https://www.stellar.org/laboratory/">Laboratory</a></li>

--- a/partials/tools/sidebar.handlebars
+++ b/partials/tools/sidebar.handlebars
@@ -1,5 +1,4 @@
 <div class="siteSidebar">
-  <h2 class="mainSectionTitle">Tools</h2>
   <div class="mainSidebar">
     <ul class="pageNavList">
       <li class="pageNavList__item"><a href="https://www.stellar.org/laboratory/">Laboratory</a></li>

--- a/src/index.handlebars
+++ b/src/index.handlebars
@@ -3,17 +3,8 @@ title: Start Developing
 previewImage: landing-1.png
 ---
 {{> head}}
+{{> header-centered}}
 
-<div class="so-back">
-  <div class="so-chunk">
-    <div class="so-siteHeader">
-      {{> siteLogo }}
-        <nav class="s-inlineList s-inlineList--wide so-siteHeader__navList spu-padStart-30 so-siteHeader__simpleAlign">
-          {{> mainNavMenu }}
-        </nav>
-    </div>
-  </div>
-</div>
 <div class="so-back so-slantContainer background-nightBlue background-starsLayer spu-padTop-40 spu-padBottom-30">
   <div class="so-chunk spu-color-neutral9 spu-padBottom-20">
     <h2 class="landing-sectionTitle">Stellar Documentation</h2>

--- a/src/js/collapsibleListSet.js
+++ b/src/js/collapsibleListSet.js
@@ -1,0 +1,37 @@
+// collapsibleListSet is a container that wraps two elements: label and list.
+// The label toggles the collapsed state of the list.
+
+// This also scans for any children that is the currentItem
+// ('.js-collapsibleListSet__list li.is-currentItem'). If any of these items
+// are present, then the collapsibleListSet's classes will be all removed.
+// The reason is for this is due to limitations on how we can style multi level
+// nested items that take up an absolute space relative to an item that is not
+// the collapsibleListSet. (see `.pageNavList__item.is-currentItem` and
+// `.pageNavListBounder`).
+
+// A collapsibleListSet's classes can also be removed if it is a child of another
+// collapsibleListSet.
+
+;(function() {
+  $('.js-collapsibleListSet').each(function(index, container) {
+    var $container = $(container);
+    var $label = $container.find('> .js-collapsibleListSet__label');
+    var $list = $container.find('> .js-collapsibleListSet__list');
+
+    if ($container.parents('.js-collapsibleListSet, .js-collapsibleListSet--nullified').length > 0
+        || $list.find('.is-currentItem').length > 0) {
+      $container.removeClass('collapsibleListSet js-collapsibleListSet');
+      $container.addClass('js-collapsibleListSet--nullified');
+      $container.find('> .js-collapsibleListSet__label').removeClass('collapsibleListSet__label is-collapsed js-collapsibleListSet__label');
+      $container.find('> .js-collapsibleListSet__list').removeClass('collapsibleListSet__list is-collapsed js-collapsibleListSet__list');
+      return;
+    }
+
+    $label.click(function() {
+      // Set up the element to transition to a set max-height. This is necessary
+      // because it is not possible to use pure css to animate height.
+      $list.css('max-height', $list[0].scrollHeight);
+      $([$label, $list]).toggleClass('is-collapsed');
+    });
+  });
+})();

--- a/src/styles/_collapsibleListSet.scss
+++ b/src/styles/_collapsibleListSet.scss
@@ -1,0 +1,27 @@
+.collapsibleListSet {
+}
+  .collapsibleListSet__label {
+    cursor: pointer;
+  }
+  .collapsibleListSet__label:after {
+    content: '';
+    display: inline-block;
+    vertical-align: middle;
+    margin-left: 6px;
+    width: 9px;
+    height: 6px;
+    background-repeat: no-repeat;
+    background-size: 9px 6px;
+    background-image: url('data:image/svg+xml;utf8,<svg width="9" height="6" viewBox="0 0 9 6" xmlns="http://www.w3.org/2000/svg"><path d="M4.5 6L9 0H0z" fill="#242A2E" fill-rule="evenodd"/></svg>');
+  }
+  .collapsibleListSet__label.is-collapsed:after {
+    background-image: url('data:image/svg+xml;utf8,<svg width="9" height="6" viewBox="0 0 9 6" xmlns="http://www.w3.org/2000/svg"><path d="M4.5 0L9 6H0z" fill="#242A2E" fill-rule="evenodd"/></svg>');
+  }
+
+  .collapsibleListSet__list {
+    overflow: hidden;
+    transition: 0.4s all;
+  }
+  .collapsibleListSet__list.is-collapsed {
+    max-height: 0 !important;
+  }

--- a/src/styles/_header2016.scss
+++ b/src/styles/_header2016.scss
@@ -1,13 +1,15 @@
-.headerWithSidebar {
+.header2016 {
   @include S-flex-row;
   border-bottom: 1px solid $s-color-neutral7;
 }
-  .headerWithSidebar__logo {
+  .header2016__logo {
     @include S-flexItem-noFlex;
     @include S-flexItem-noFlex;
-    width: 288px;
-    padding-left: 2em;
   }
-  .headerWithSidebar__nav {
+    .header2016__logo--spaced {
+      width: 288px;
+      padding-left: 2em;
+    }
+  .header2016__nav {
     @include S-flexItem-share;
   }

--- a/src/styles/_headerWithSidebar.scss
+++ b/src/styles/_headerWithSidebar.scss
@@ -1,11 +1,13 @@
 .headerWithSidebar {
-  width: auto;
+  @include S-flex-row;
+  border-bottom: 1px solid $s-color-neutral7;
 }
   .headerWithSidebar__logo {
+    @include S-flexItem-noFlex;
     @include S-flexItem-noFlex;
     width: 288px;
     padding-left: 2em;
   }
   .headerWithSidebar__nav {
-
+    @include S-flexItem-share;
   }

--- a/src/styles/_headerWithSidebar.scss
+++ b/src/styles/_headerWithSidebar.scss
@@ -1,0 +1,11 @@
+.headerWithSidebar {
+  width: auto;
+}
+  .headerWithSidebar__logo {
+    @include S-flexItem-noFlex;
+    width: 288px;
+    padding-left: 2em;
+  }
+  .headerWithSidebar__nav {
+
+  }

--- a/src/styles/_mainNavMenu.scss
+++ b/src/styles/_mainNavMenu.scss
@@ -1,0 +1,17 @@
+.mainNavMenu {
+  @include S-flex-row;
+  align-items: stretch;
+}
+  .mainNavMenu__item {
+    margin-right: 3em;
+    margin-top: 29px;
+    color: $s-color-primary4;
+    text-decoration: none;
+  }
+  .mainNavMenu__item:hover {
+    color: $s-color-neutral3;
+  }
+  .mainNavMenu__item.is-currentItem {
+    color: $s-color-neutral3;
+    border-bottom: 5px solid $s-color-neutral4;
+  }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -133,7 +133,7 @@ s-read-md .codeBlock {
   font-weight: bold;
 }
 .pageNavList__item a:hover {
-  color: $s-color-primary1;
+  color: $s-color-neutral2;
   text-decoration: underline;
 }
 .pageNavList__subList {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -14,6 +14,7 @@
 @import 'anchorShortcut';
 
 @import 'headerWithSidebar';
+@import 'mainNavMenu';
 @import 'siteFooter';
 
 @import 'pages/landing';

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -13,7 +13,7 @@
 @import 'backgrounds';
 @import 'anchorShortcut';
 
-@import 'headerWithSidebar';
+@import 'header2016';
 @import 'mainNavMenu';
 @import 'siteFooter';
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -28,8 +28,7 @@
   color: $s-color-neutral2;
 }
 .mainSidebar {
-  border-top: 1px solid $s-color-neutral7;
-  padding-top: 2em;
+  padding-top: 1.5em;
 }
 .mainContent {
   max-width: 900px;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -39,7 +39,7 @@
   @include S-flexItem-noFlex;
   width: 288px;
   padding-left: 2em;
-  background: $s-color-neutral8;
+  background: $s-color-primary9;
   padding-bottom: 2em;
 }
 
@@ -92,6 +92,9 @@ s-read-md .codeBlock {
   margin-bottom: 0;
 }
 
+.pageNavListBounder {
+  position: relative;
+}
 .pageNavList {
   list-style: none;
 }
@@ -108,15 +111,26 @@ s-read-md .codeBlock {
 .pageNavList__title {
   font-weight: 700;
 }
-.pageNavList__item a {
+.pageNavList__item.is-currentItem:before {
+  content: '';
+  z-index: 0;
+  position: absolute;
+  left: 0;
+  right: 0;
   display: block;
-  border-right: 0.4em solid transparent;
-  color: $s-color-primary2;
+  border-left: 10px solid $s-color-primary4;
+  height: 1.5em;
+  background: $s-color-neutral9;
+}
+.pageNavList__item a {
+  z-index: 1;
+  position: relative;
+  display: block;
+  color: $s-color-neutral2;
   text-decoration: none;
 }
 .pageNavList__item.is-currentItem a {
-  color: $s-color-neutral3;
-  border-color: $s-color-neutral3;
+  font-weight: bold;
 }
 .pageNavList__item a:hover {
   color: $s-color-primary1;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -13,6 +13,7 @@
 @import 'backgrounds';
 @import 'anchorShortcut';
 
+@import 'headerWithSidebar';
 @import 'siteFooter';
 
 @import 'pages/landing';

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -16,6 +16,7 @@
 @import 'header2016';
 @import 'mainNavMenu';
 @import 'siteFooter';
+@import 'collapsibleListSet';
 
 @import 'pages/landing';
 


### PR DESCRIPTION
It looks something like this:
![image](https://cloud.githubusercontent.com/assets/5728307/13026646/83c6f366-d26a-11e5-84ee-841bc571129d.png)

# Caveats:

## Single line highlighting
Making the current item highlighting with the blue thing extending all the way to the left (but not limited to) made the styling extremely difficult since there are multiple levels of indentations. This is the best possible outcome with css.
![image](https://cloud.githubusercontent.com/assets/5728307/13037600/b3795d82-d3bf-11e5-8496-880024cf6117.png)

### Solution to `Single line highlighting` (remove blue rectangle)
The cause of this is that the design calls for a blue rectangle exactly at the left side of the nav. This is difficult to do because some items start off at different indentation levels. If we get rid of the blue rectangle or move it to the right side, then this single line highlighting issue will be gone. 

## Current family not collapsible
Because of how the "current" state is implemented (due to the blue rectangle), menus with a current item can not be collapsed or else the "current" state will persist with the menu closed.

### Solution (remove blue rectangle)
This can either be solved by a hack or by getting rid of the blue rectangle.

## Flash of unstyled content (menu item flashing)
Upon loading the page, there is a flash before the menu opens up to the list containing the current item.

### Solution  (1-2 days worth of work)
The flash of unstyled content (FOUC) can be solved by running the JS currently run on the browser to be run during build time (ie. Jenkins build server). This will take about 1-2 days worth of work to get right.