### PR TITLE
Remove interstellar navigation

### DIFF
--- a/partials/learn/sidebar.handlebars
+++ b/partials/learn/sidebar.handlebars
@@ -31,11 +31,6 @@
         {{>sidebarSubItems glob="stellar-core/learn/*.html"}}
         {{>sidebarSubItems glob="stellar-core/learn/*.pdf"}}
       {{/sidebarSubMenu}}
-
-      {{#sidebarSubMenu "Interstellar"}}
-        {{>sidebarSubItems glob="interstellar/learn/index.html"}}
-        {{>sidebarSubItems glob="interstellar/learn/!(index).html"}}
-      {{/sidebarSubMenu}}
     </ul>
   </div>
 </div>


### PR DESCRIPTION
This is so that people do not get confused and start reading interstellar docs when the sdk or Horizon docs are more what they need.

- First commit simply 'unlists' it
- ~~Second commit (`remove interstellar from build process`) will cause all the current interstellar pages to become 404 pages.~~

#### ~~Are we okay with letting the current interstellar pages hosted on the developers site becoming 404?  Maybe we should just leave them there but just unlisted?~~

#### *edit* I force pushed. Now, it will just be unlisted but the pages will still exist
