### PR TITLE
remove xdr viewer from tools sidebar

### DIFF
--- a/partials/tools/sidebar.handlebars
+++ b/partials/tools/sidebar.handlebars
@@ -7,7 +7,6 @@
     <ul class="pageNavList">
       <li class="pageNavList__item"><a href="https://www.stellar.org/laboratory/">Laboratory</a></li>
       <li class="pageNavList__item"><a href="https://www.stellar.org/account-viewer/">Account Viewer</a></li>
-      <li class="pageNavList__item"><a href="https://bartekn.github.io/stellar-xdr-debugger/">XDR Viewer</a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/5728307/14534658/005379d4-021f-11e6-9e23-25fb9a7ee502.png)

I missed a spot when removing the xdr viewer a while ago