### PR TITLE
Add incremental + live building. Fixes #20.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ node_modules/.bin/gulp # or just `gulp` if you have it installed globally or hav
 To run a web server and view the site in a browser:
 
 ```bash
-node_modules/.bin/gulp serve
+node_modules/.bin/gulp watch serve
 ```
 
-This won't automatically rebuild the site when edits are made, but it will automatically pick up new builds (so you can do a build without needing to restart the server).
+This will also automatically rebuild the site when edits are made. (To serve without rebuilding, drop the `watch` argument.)
 
 By default, the site is served under the developers/ subfolder. This is to reduce the amount of bugs when this site is deployed to https://www.stellar.org/developers/. This can be changed by passing a custom baseUrl to the gulp build task like so: `gulp --baseUrl="/"` or `gulp build --baseUrl="/"`.
 

--- a/gulp/handlebars.js
+++ b/gulp/handlebars.js
@@ -61,6 +61,12 @@ module.exports.helpers = {
     }
     return `<script>window.clientData = ${clientDataJson};</script>`;
   },
+
+  // If available, return the fingerprinted version of a path, otherwise just
+  // return the path as-is.
+  fingerprint (path) {
+    return this.fingerprint && this.fingerprint[path] || path;
+  }
 }
 
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "markdown-it-footnote": "^2.0.0",
     "metalsmith": "git+https://github.com/stellar/metalsmith.git",
     "metalsmith-autoprefixer": "^1.1.0",
+    "metalsmith-changed": "^2.0.0",
     "metalsmith-concat": "^3.0.3",
     "metalsmith-fingerprint": "^1.0.3",
     "metalsmith-in-place": "^1.3.1",

--- a/partials/head.handlebars
+++ b/partials/head.handlebars
@@ -20,7 +20,7 @@
     <meta itemprop="image" content="https://www.stellar.org{{ pathPrefix }}/images/previews/{{previewImage}}"/>
   {{/if}}
 
-  <link rel="stylesheet" href="{{ pathPrefix }}/{{ fingerprint.[styles/index.css] }}" />
+  <link rel="stylesheet" href="{{ pathPrefix }}/{{fingerprint 'styles/index.css'}}" />
 
   <link rel="apple-touch-icon" sizes="144x144" href="{{ pathPrefix }}/images/favicon/rocket-144x144.png">
   <link rel="apple-touch-icon" sizes="152x152" href="{{ pathPrefix }}/images/favicon/rocket-152x152.png">


### PR DESCRIPTION
Pretty much what it says on the tin.

You can build incrementally (build only the files that changed) with:

```sh
gulp build --incremental
```

And you can watch and incrementally rebuild with:

```sh
gulp watch
```

And best of all you can serve and auto rebuild with:

```sh
gulp watch serve
```

It will also auto-reload the content in the browser for you (this was already set up, but wasn't triggered before unless you messed around in the build output files).