### PR TITLE
Fix app.js fingerprinting (missed this in #69)

### DIFF
--- a/partials/foot.handlebars
+++ b/partials/foot.handlebars
@@ -1,5 +1,5 @@
 </body>
-<script src="{{pathPrefix}}/{{ fingerprint.[js/app.js] }}"></script>
+<script src="{{pathPrefix}}/{{fingerprint 'js/app.js'}}"></script>
 <script type="text/javascript">
 !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="3.1.0";
 analytics.load("U8cLXTFMPm");

--- a/partials/head.handlebars
+++ b/partials/head.handlebars
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">


### PR DESCRIPTION
Missed a fingerprint call in #69, so this fixes it :\

Also fixes capitalization of HTML5 DOCYPE declaration while we’re at it.