### PR TITLE
Remove beyond-code section

### DIFF
--- a/src/beyond-code
+++ b/src/beyond-code
@@ -1,1 +1,0 @@
-../repos/docs/beyond-code


### PR DESCRIPTION
The underlying section this symlink pointed to was removed in https://github.com/stellar/docs/pull/147 and now needs to removed here.