### PR TITLE
Minor code example fixes

### DIFF
--- a/src/js/codeExamples.js
+++ b/src/js/codeExamples.js
@@ -8,7 +8,8 @@
   var MATCH_LANGUAGE = /(?:lang|language)-([a-zA-Z]+)/;
   var LANGUAGE_NAMES = {
     sh: 'Bash',
-    js: 'JavaScript'
+    js: 'JavaScript',
+    json: 'JSON'
   };
   var DEFAULT_LANGUAGE = 'js';
   var STORAGE_KEY = 'code-examples';

--- a/src/js/codeExamples.js
+++ b/src/js/codeExamples.js
@@ -105,7 +105,8 @@
     for (var language in this.examples) {
       var visible = language === value;
       $(this.examples[language]).css('display', visible ? '' : 'none');
-      $('.language-switcher--setter[data-language="' + language + '"]')
+      $('.language-switcher--setter[data-language="' + language + '"]',
+        this.element)
         .toggleClass('selected', visible);
     }
     
@@ -127,6 +128,5 @@
   $('code-example').each(function(index, element) {
     new Switcher(element);
   });
-  
   
 })(jQuery);


### PR DESCRIPTION
This fixes the capitalization of “Json” (now “JSON”) for the language switcher and also fixes an issue where multiple code examples on a single page with differing sets of language options conflicted with each other (e.g. one sample also has a “JSON” option because it is describing data from Horizon while the rest are only JS/Java/Go because they are about performing an operation).