### PR TITLE
Add lightweight math display

### DIFF
--- a/gulp/math-formula.js
+++ b/gulp/math-formula.js
@@ -1,0 +1,81 @@
+import _ from "lodash";
+import path from "path";
+
+/**
+ * Ultra-simple math formula formatting (as Metalsmith middleware).
+ * A richer version might use Ascii2MathML (runarberg.github.io/ascii2mathml) or
+ * MathJax (mathjax.org), but:
+ *   - MathML support is not so good (http://caniuse.com/#feat=mathml)
+ *   - MathJax can do a nice non-MathML render, but it is a little complex and
+ *     it (and AsciiMath) is very oriented towards traditional mathematical
+ *     formulae and doesn't some constructs we'd like well (e.g. multiplication
+ *     symbols, pretty variable names with spaces).
+ * So, do something simpler here which suits our purposes for now.
+ *
+ * Finds "```math-formula" code blocks in Markdown and converts them to
+ * `<div class="math-formula">` with some additional typography cleanup and
+ * markup/classes around types of symbols (operators, parens, etc)
+ */
+export default function mathFormula(files, metalsmith, done) {
+  _.chain(files)
+    .filter(isMarkdown)
+    .each(file => {
+      file.contents = file.contents.toString().replace(
+        /\n```math-formula\n((?:.|\n)*?)\n```\n/g,
+        (token, content) => `\n${formatFormula(content)}\n`);
+    })
+    .value();
+  done();
+}
+
+function isMarkdown(file, filePath) {
+  return /\.(md|markdown|mdown)$/.test(path.extname(filePath));
+}
+
+function formatFormula(text) {
+  const formatted =
+    prettyParentheses(
+      prettyVariables(
+        prettyNumbers(
+          prettyExponents(
+            prettyOperators(text)))));
+  return `<div class="math-formula">${formatted}</div>`;
+}
+
+function prettyOperators(text) {
+  return text
+    .replace(/\*/g, '×')
+    .replace(/\//g, '÷')
+    .replace(/\+-/g, '±')
+    .replace(/\-/g, '−')
+    .replace(/\!=/g, '≠')
+    .replace(/<=/g, '≤')
+    .replace(/>=/g, '≥')
+    .replace(
+      /([×÷=≠≤≥]|\s[+−]\s)/g,
+      '<span class="math-formula-operator">$1</span>');
+}
+
+function prettyVariables(text) {
+  return text.replace(/\[(.+?)\]/g, '<var>$1</var>');
+}
+
+// NOTE: this won't handle [variables with spaces]; we'd need more rigorous
+// parsing than this simple pile of regexes for that.
+function prettyExponents(text) {
+  return text
+    .replace(/\^\(([^)]+)\)/g, '<sup>$1</sup>')
+    .replace(/\^(\S+)/g, '<sup>$1</sup>');
+}
+
+function prettyParentheses(text) {
+  return text
+    // NOTE: the parenthesis character in the replacement is a special paren 
+    .replace(/\(/g, '<span class="math-formula-paren open">(</span>')
+    .replace(/\)/g, '<span class="math-formula-paren close">)</span>');
+}
+
+function prettyNumbers(text) {
+  return text
+    .replace(/\d+(\.\d*)?/g, '<span class="math-formula-number">$&</span>');
+}

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -157,7 +157,10 @@ function build({clean = false, incremental = false}, done) {
       hbars.setFileList(renamedFiles);
       done();
     })
-    .use($m.changed())
+    .use($m.changed({
+      forcePattern: '**/index*.css'
+    }))
+    .use(require("./gulp/math-formula.js"))
     .use($m.markdownit({
       html: true,
       linkify: true,

--- a/src/styles/_mathFormula.scss
+++ b/src/styles/_mathFormula.scss
@@ -1,13 +1,28 @@
 .math-formula {
+  .math-formula-paren {
+    font-weight: lighter;
+    opacity: 0.25;
+  }
+  
+  .math-formula-operator {
+    opacity: 0.8;
+  }
+  
+  var {
+    border-bottom: 1px solid $s-color-neutral7;
+    line-height: 1;
+    white-space: nowrap;
+  }
+}
+
+figure.math-formula {
   display: block;
   font-size: 1.5em;
   margin: 1em;
   text-align: center;
-  
+
   .math-formula-paren {
     font-size: 1.5em;
-    font-weight: lighter;
-    opacity: 0.25;
     
     &.open {
       margin-right: 0.25em;
@@ -18,12 +33,11 @@
   }
   
   .math-formula-operator {
-    opacity: 0.8;
     margin: 0 0.2em;
   }
-  
-  var {
-    border-bottom: 1px solid #ddd;
-    line-height: 1;
-  }
+}
+
+code.math-formula {
+  margin: 0 0.1em;
+  padding: 0em 0.1em 0.1em;
 }

--- a/src/styles/_mathFormula.scss
+++ b/src/styles/_mathFormula.scss
@@ -1,0 +1,29 @@
+.math-formula {
+  display: block;
+  font-size: 1.5em;
+  margin: 1em;
+  text-align: center;
+  
+  .math-formula-paren {
+    font-size: 1.5em;
+    font-weight: lighter;
+    opacity: 0.25;
+    
+    &.open {
+      margin-right: 0.25em;
+    }
+    &.close {
+      margin-left: 0.25em;
+    }
+  }
+  
+  .math-formula-operator {
+    opacity: 0.8;
+    margin: 0 0.2em;
+  }
+  
+  var {
+    border-bottom: 1px solid #ddd;
+    line-height: 1;
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -14,6 +14,7 @@
 @import 'anchorShortcut';
 @import 'footnotes';
 @import 'codeExamples';
+@import 'mathFormula';
 
 @import 'header2016';
 @import 'mainNavMenu';


### PR DESCRIPTION
This adds some very simple support for nicely displaying mathematical formulas (currently used in the fees doc: https://github.com/stellar/docs/pull/155). It surrounds various tokens (parens, operators, variables, etc) with DOM elements, and cleans up typography (proper multiplication, division, ≤, ≥).

<img width="806" alt="screen shot 2016-08-11 at 1 28 31 am" src="https://cloud.githubusercontent.com/assets/74178/17583094/1cb956be-5f64-11e6-842b-f551a96ecdb6.png">

We could do something a bit richer using MathJax, but it would be much heavier weight, imposes some *slightly* less readable syntax (AsciiMath), and doesn't handle vars with spaces (as in the example above), so this simple implementation seemed to serve our purposes here a bit better. Totally open to changing that, though.

Formulas can be inline (delimited by `$$`) or block (code fences with the language set to `math-formula`, e.g:

    ```math-formula
    (2 + [# of entries]) * [base reserve]
    ```