### PR TITLE
Add debug flag to include sourcemaps in build

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ This will also automatically rebuild the site when edits are made. (To serve wit
 
 By default, the site is served under the developers/ subfolder. This is to reduce the amount of bugs when this site is deployed to https://www.stellar.org/developers/. This can be changed by passing a custom baseUrl to the gulp build task like so: `gulp --baseUrl="/"` or `gulp build --baseUrl="/"`.
 
+When working on the site, you can also use the `--debug` option to generate output that is easier to debug in the browser (it includes things like sourcemaps).
+
+
 ### Browser JavaScript
 Browser JavaScript files live in [`src/js`](/src/js/). `vendor.js` is generated from bower_components and not checked in to the repository.
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -95,7 +95,7 @@ function renameHandlebars (files, metalsmith, done) {
   done();
 }
 
-function build({clean = false, incremental = false}, done) {
+function build({clean = false, incremental = false, debug = !!argv.debug}, done) {
 
   let templateOptions = {
     engine: "handlebars",
@@ -104,16 +104,25 @@ function build({clean = false, incremental = false}, done) {
     preventIndent: true,
   };
 
+  const sassOptions = {
+    outputStyle: "expanded",
+    includePaths: [ "./node_modules", "./bower_components" ]
+  };
+  if (debug) {
+    Object.assign(sassOptions, {
+      sourceMap: true,
+      sourceMapContents: true,
+      sourceMapEmbed: true
+    });
+  }
+
   const pipeline = Metalsmith(__dirname)
     .clean(!incremental)
     .metadata({ pathPrefix: PATH_PREFIX })
     .use(extract.examples)
     .use(require("./gulp/sidecarMetadata"))
     .use(require("./gulp/enhance"))
-    .use($m.sass({
-      outputStyle: "expanded",
-      includePaths: [ "./node_modules", "./bower_components" ]
-    }))
+    .use($m.sass(sassOptions))
     .use($m.autoprefixer({ }))
     .use($m.concat({
       files: [


### PR DESCRIPTION
This makes figuring out what’s going on with the CSS much easier. It could be extended in the future for uglifying/not uglifying JS, JS sourcemaps (if building with rollup, webpack, babel, etc), and so on.