### PR TITLE
Point build challenge link on home page to actual page (not blog)

### DIFF
--- a/src/index.handlebars
+++ b/src/index.handlebars
@@ -99,7 +99,7 @@ previewImage: landing-2.png
   <section class="so-chunk spu-pad-20 centerText spu-color-neutral9 landing0616-buildApps__chunk">
     <div class="spu-padBottom-20"><span class="graphic-prototypeGear"></span></div>
     <h2 class="landing-sectionTitle spu-color-neutral9">Develop the future of finance</h2>
-    <p class="spu-fontSize-3 landing0616-buildApps__lead spu-padBottom-10">Build microsavings accounts for school fees or health insurance, or a Slack bot to report a transaction stream. Develop a project to enter in the <a href="https://www.stellar.org/blog/build-challenge/">Stellar Build Challenge</a>.</p>
+    <p class="spu-fontSize-3 landing0616-buildApps__lead spu-padBottom-10">Build microsavings accounts for school fees or health insurance, or a Slack bot to report a transaction stream. Develop a project to enter in the <a href="https://www.stellar.org/lumens/build/">Stellar Build Challenge</a>.</p>
     <p>
       <a href="https://www.stellar.org/how-it-works/powered-by-stellar/" class="s-button landing0616-cta spu-textUppercase">Build Stellar Apps</a>
     </p>


### PR DESCRIPTION
There was previously no permanent page for the build challenge, so we linked to the blog post. Now that there’s a page, we should link to it instead.