### PR TITLE
Display footnotes as popovers

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "jquery": "~2.1.4",
     "codemirror": "~5.6.0",
-    "stellar-sdk": "0.2.16"
+    "stellar-sdk": "0.2.16",
+    "tether-drop": "drop#^1.4.2"
   }
 }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -49,6 +49,8 @@ gulp.task('js:copy-vendor', function() {
     './bower_components/codemirror/mode/go/go.js',
     './bower_components/codemirror/mode/toml/toml.js',
     './bower_components/stellar-sdk/stellar-sdk.min.js',
+    './bower_components/tether/dist/js/tether.min.js',
+    './bower_components/tether-drop/dist/js/drop.min.js',
   ])
     .pipe($g.concat('vendor.js'))
     .pipe(gulp.dest('./src/js'));
@@ -63,6 +65,7 @@ gulp.task('serve', () => {
     .pipe($g.webserver({
       livereload: true,
       open: "index.html",
+      host: '0.0.0.0'
     }));
 });
 
@@ -135,6 +138,7 @@ function build({clean = false, incremental = false, debug = !!argv.debug}, done)
         "js/friendbot4.js",
         "js/collapsibleListSet.js",
         "js/linkCheck.js",
+        "js/footnotes.js",
       ],
       output: "js/app.js",
     }));

--- a/src/js/footnotes.js
+++ b/src/js/footnotes.js
@@ -1,0 +1,34 @@
+/* global Drop */
+
+/**
+ * Display footnotes as popovers.
+ */
+(function($) {
+  'use strict';
+
+  var SUPPORTS_TOUCH = 'createTouch' in document;
+
+  function createFootnoteDropdown(footnoteLink) {
+    var content = $(footnoteLink.getAttribute('href'));
+    if (!content.length) return;
+
+    var noteNode = document.createElement('s-read-md');
+    $(noteNode)
+      .append(content.clone().children())
+      .find('.footnote-backref')
+        .remove();
+
+    return new Drop({
+      target: footnoteLink.parentNode,
+      position: 'bottom center',
+      classes: 'drop-theme-arrows footnote-drop',
+      openOn: SUPPORTS_TOUCH ? 'click' : 'hover',
+      content: noteNode
+    });
+  }
+
+  $('.footnote-ref a').each(function(index, element) {
+    createFootnoteDropdown(element);
+  });
+
+})(jQuery);

--- a/src/styles/_footnotes.scss
+++ b/src/styles/_footnotes.scss
@@ -1,4 +1,7 @@
 .footnotes-sep {
   border: none;
   border-top: 1px solid $s-color-neutral7;
+  // like most text content, .footnotes-sep has a max-width. However, it is
+  // normally centered. Remove the left margin so it lines up with content.
+  margin-left: 0;
 }

--- a/src/styles/_footnotes.scss
+++ b/src/styles/_footnotes.scss
@@ -1,7 +1,42 @@
+// Note Drop also provides SASS content we could use for more customization.
+@import '../../bower_components/tether-drop/dist/css/drop-theme-arrows.min';
+
+// Line separating footnotes from rest of document
 .footnotes-sep {
   border: none;
   border-top: 1px solid $s-color-neutral7;
   // like most text content, .footnotes-sep has a max-width. However, it is
   // normally centered. Remove the left margin so it lines up with content.
   margin-left: 0;
+}
+
+// Popover for displaying footnotes in context
+.drop-element.footnote-drop {
+  $background-color: whiten($s-color-neutral8, 50%);
+  opacity: 0;
+
+  &.drop-after-open {
+    transition: opacity 0.25s;
+    opacity: 1;
+  }
+
+  // Set the color of the "arrow" in the popover
+  &.drop-element-attached-bottom.drop-element-attached-center .drop-content:before {
+    border-top-color: $background-color;
+  }
+  &.drop-element-attached-top.drop-element-attached-center .drop-content:before {
+    border-bottom-color: $background-color;
+  }
+
+  .drop-content {
+    background: $background-color;
+    max-width: 30em;
+    filter:
+      drop-shadow(0 0px 1px $s-color-neutral5)
+      drop-shadow(0 1px 8px rgba(0, 0, 0, 0.2));
+
+    p:last-child {
+      margin-bottom: 0;
+    }
+  }
 }


### PR DESCRIPTION
Basically: 
![screen shot 2016-10-06 at 4 45 25 pm](https://cloud.githubusercontent.com/assets/74178/19174546/5d7c33c2-8be4-11e6-9ce5-2ee8ec6c7441.png)

Also fixes another minor footnote styling issue (alignment of the separator line)

Uses the [Tether](http://tether.io/docs/welcome/) and [Drop](http://github.hubspot.com/drop/docs/welcome/) libraries from Hubspot, which are generally very flexible and reliable.