### PR TITLE
WIP: Turn symbols in code samples into links/popovers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /build
 /repos
 /src/js/vendor.js
+/src/js/*-symbols.json
 
 ###
 # node.js and bower

--- a/gulp/code-symbol-tags.js
+++ b/gulp/code-symbol-tags.js
@@ -1,0 +1,122 @@
+/**
+ * Generate JSON summaries of symbols from Stellar SDKs for use when syntax
+ * highlighting code samples in documentation.
+ *
+ * TODO: other SDKs besides JS
+ * TODO: does this belong as a CLI script in each SDK repo instead?
+ * TODO: is there a JS API for JSDoc we can/should use instead?
+ */
+
+import child_process from 'child_process';
+import cheerio from 'cheerio';
+
+const DOCUMENTATION_URL = 'https://stellar.github.io/js-stellar-sdk/';
+
+export function javascriptSymbols(callback) {
+  let output = '';
+  let error = '';
+
+  const jsDoc = child_process.spawn(
+    './node_modules/.bin/jsdoc',
+    [
+      '-c', '.jsdoc.json',
+      '--explain' // output doclet JSON instead of templated web site
+    ],
+    {
+      cwd: './repos/js-stellar-sdk/'
+    });
+
+  jsDoc.stdout.on('data', data => output += data);
+  jsDoc.stderr.on('data', data => error += data);
+  jsDoc.on('exit', code => {
+    if (code === 0) {
+      const doc = parseDoclets(output);
+      callback(null, doc.names);
+    }
+    else {
+      callback(error, null);
+    }
+  });
+}
+
+function parseDoclets (rawString) {
+  const doclets = JSON.parse(rawString);
+
+  const parsed = doclets.reduce((result, doclet) => {
+    if (
+      doclet.name &&
+      !doclet.name.startsWith('_') &&
+      doclet.description &&
+      !(result.longnames[doclet.longname] && result.longnames[doclet.longname].description) &&
+      !doclet.undocumented) {
+
+      const finalDoclet = simplifiedDoclet(doclet);
+      result.longnames[doclet.longname] = finalDoclet;
+      if (!result.names[doclet.name]) {
+        result.names[doclet.name] = [];
+      }
+      result.names[doclet.name].push(finalDoclet);
+    }
+    return result;
+  }, {
+    longnames: {},
+    names: {}
+  });
+
+  return parsed;
+}
+
+/**
+ * Create a standardized, minimal doc object from a JSDoc doclet.
+ * @param {JSDocDoclet} doclet
+ * @return {{kind: String, name: String, longname: String, params: Array}}
+ */
+function simplifiedDoclet (doclet) {
+  const result = {
+    kind: doclet.kind,
+    name: doclet.name,
+    longName: doclet.longname,
+    url: urlForSymbol(doclet.longname, DOCUMENTATION_URL),
+    description: formatDescription(doclet.description, DOCUMENTATION_URL)
+  };
+  if (doclet.memberof) {
+    result.memberOf = doclet.memberof;
+  }
+  // Params take up a lot of space & we don't use them, but may want them later.
+  // if (doclet.params) {
+  //   result.params = doclet.params;
+  // }
+  return result;
+}
+
+function formatDescription (text, baseUrl) {
+  let formatted = convertLinksToHTML(text, baseUrl);
+  const $ = cheerio.load(formatted);
+
+  // remove example code
+  $('.source').remove();
+
+  // TODO: clip at a certain number of words or characters?
+
+  return $.html();
+}
+
+// Find calls for links to other symbols in a description. Captures 1 is the
+// target of the link.
+const LINK_MATCHER = /\{\@link\s([^}]+)\}/g;
+
+// Break up a target into the owner and member being targeted. The member
+// includes the type specifier (e.g. '.') for all but instance members.
+const TARGET_PARTS = /^(\w+)\#?(.*)$/;
+
+function convertLinksToHTML (text, baseUrl) {
+  return text.replace(LINK_MATCHER, (match, target) => {
+    const url = urlForSymbol(target, baseUrl);
+    return `<a href="${url}">${target}</a>`;
+  });
+}
+
+function urlForSymbol (symbol, baseUrl) {
+  const [_, owner, member] = symbol.match(TARGET_PARTS);
+  return `${baseUrl}${owner}.html#${member}`;
+}

--- a/src/js/codeSymbolLinks.js
+++ b/src/js/codeSymbolLinks.js
@@ -179,7 +179,7 @@
       linkCommentUrls(element);
     });
 
-    var highlightedCode = $('pre > code.language-js');
+    var highlightedCode = $('pre > code.language-js, pre > code.language-javascript, pre > code.language-node');
     if (!highlightedCode.length) return;
 
     loadSymbols().then(function(symbols) {

--- a/src/js/codeSymbolLinks.js
+++ b/src/js/codeSymbolLinks.js
@@ -91,18 +91,17 @@
 
     // This approach could potentially have a lot of false positives, but if we
     // keep example code nicely written, it should be workable.
-    for (var name in symbols) {
+    $('.cm-property', element).each(function(index, propertyElement) {
+      // don't re-link symbols we already found
+      if (propertyElement.children.length) return;
+
+      var propertyName = $.trim(propertyElement.textContent);
       // TODO: can we make any good inferences that allow us to handle multiple
       // types with the same members, e.g. Keypair#sign vs. Transaction#sign
-      if (symbols[name].length !== 1) continue;
-      var symbol = symbols[name][0];
-      $('.cm-property:contains("' + name + '")', element).each(function(index, propertyElement) {
-        // don't re-link symbols we already found
-        if (!propertyElement.children.length) {
-          replaceWithLink(propertyElement, symbol);
-        }
-      });
-    }
+      if ((symbols[propertyName] || []).length !== 1) return;
+      var symbol = symbols[propertyName][0];
+      replaceWithLink(propertyElement, symbol);
+    });
   }
 
   var URL_EXPRESSION = /\b((?:[a-z][\w-]+:(?:\/{1,3}|[a-z0-9%])|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}\/)(?:[^\s()<>\[\]'"]+|\([^\s()<>\[\]'"]*\))+(?:\([^\s()<>\[\]'"]*\)|[^\s`!()\[\]{}:'".,<>?«»“”‘’]))/gi;

--- a/src/js/codeSymbolLinks.js
+++ b/src/js/codeSymbolLinks.js
@@ -1,0 +1,125 @@
+/* global Drop */
+
+(function($) {
+  'use strict';
+
+  var SUPPORTS_TOUCH = 'createTouch' in document;
+
+  function loadSymbols() {
+    return $.ajax({
+      // FIXME: need to grab a base url from somewhere
+      url: '/js/javascript-symbols.json',
+      dataType: 'json'
+    });
+  }
+
+  function setupStyles() {
+    var style = document.createElement('style');
+    style.type = 'text/css';
+    style.innerHTML = 'pre > code a[rel=documentation] { color: inherit; }';
+    document.head.appendChild(style);
+  }
+
+  function replaceWithLink(element, symbol) {
+    var link = document.createElement('a');
+    link.appendChild(document.createTextNode(element.textContent));
+    link.rel = 'documentation';
+    link.href = symbol.url;
+    link.target = '_blank';
+
+    if (symbol.description) {
+      var dropContent = document.createElement('div');
+      var description = document.createElement('s-read-md');
+      description.className = 'symbol-description';
+      description.innerHTML = symbol.description;
+      dropContent.appendChild(description);
+      $(dropContent).find('a').each(function(index, link) {
+        if (isOffsiteUrl(link.href)) {
+          link.target = '_blank';
+        }
+      });
+
+      var readMoreLink = document.createElement('a');
+      readMoreLink.href = symbol.url;
+      readMoreLink.target = '_blank';
+      readMoreLink.textContent = 'Read Full Documentation';
+      dropContent.appendChild(readMoreLink);
+
+      new Drop({
+        target: link,
+        position: 'bottom center',
+        classes: 'drop-theme-arrows api-reference-drop',
+        openOn: SUPPORTS_TOUCH ? 'click' : 'hover',
+        hoverOpenDelay: 1000,
+        content: dropContent
+      });
+    }
+
+    $(element).empty().append(link);
+    return link;
+  }
+
+  function linkSymbols(element, symbols) {
+    $('.cm-variable:contains("StellarSdk") + .cm-property', element).each(function(index, propertyElement) {
+      var symbolName = $.trim(propertyElement.textContent);
+      var candidates = symbols[symbolName];
+
+      // TODO: handle >1 candidates?
+      if (!candidates || candidates.length !== 1) return;
+
+      var symbol = candidates[0];
+      replaceWithLink(propertyElement, symbol);
+
+      // this is a little messy, but we want to link the next one, too, e.g:
+      // StellarSdk.Keypair.fromSeed <- link both `Keypair` and `fromSeed`
+      var nextProperty = $(propertyElement).next('.cm-property')[0];
+      if (!nextProperty) return;
+      var nextName = $.trim(nextProperty.textContent);
+      candidates = symbols[nextName];
+      if (!candidates) return;
+
+      var nextSymbol;
+      for (var i = 0, len = candidates.length; i < len; i++) {
+        if (candidates[i].memberOf === symbol.name) {
+          nextSymbol = candidates[i];
+          break;
+        }
+      }
+      if (!nextSymbol) return;
+      replaceWithLink(nextProperty, nextSymbol);
+    });
+
+    // This approach could potentially have a lot of false positives, but if we
+    // keep example code nicely written, it should be workable.
+    for (var name in symbols) {
+      // TODO: can we make any good inferences that allow us to handle multiple
+      // types with the same members, e.g. Keypair#sign vs. Transaction#sign
+      if (symbols[name].length !== 1) continue;
+      var symbol = symbols[name][0];
+      $('.cm-property:contains("' + name + '")', element).each(function(index, propertyElement) {
+        // don't re-link symbols we already found
+        if (!propertyElement.children.length) {
+          replaceWithLink(propertyElement, symbol);
+        }
+      });
+    }
+  }
+
+  function isOffsiteUrl(url) {
+    var hostname = url && url.match(/^(?:\w+:\/\/(?:\/?))?([^\/]+)/);
+    return hostname && hostname[1] !== window.location.hostname;
+  }
+
+  $(function() {
+    var highlightedCode = $('pre > code.language-js');
+    if (!highlightedCode.length) return;
+
+    loadSymbols().then(function(symbols) {
+      setupStyles();
+      highlightedCode.each(function(index, element) {
+        linkSymbols(element, symbols);
+      });
+    });
+  });
+
+})(jQuery);

--- a/src/js/footnotes.js
+++ b/src/js/footnotes.js
@@ -8,10 +8,16 @@
 
   var SUPPORTS_TOUCH = 'createTouch' in document;
 
+  /**
+   * Clone the footnote associated with a reference link and display it as a
+   * popover so the user can see the footnote in context.
+   * @param {Element} footnoteLink
+   */
   function createFootnoteDropdown(footnoteLink) {
     var content = $(footnoteLink.getAttribute('href'));
     if (!content.length) return;
 
+    // Our text styles are scoped to <s-read-md>, so wrap the footnote in one.
     var noteNode = document.createElement('s-read-md');
     $(noteNode)
       .append(content.clone().children())

--- a/src/styles/_codeExamples.scss
+++ b/src/styles/_codeExamples.scss
@@ -16,11 +16,11 @@ code-example pre {
   color: $s-color-neutral4;
   font-size: 0.75em;
   padding: 0.5em 1em 0 1em;
-  
+
   .code-example-title {
     margin-right: 2em;
   }
-  
+
   .language-switcher--setter {
     border: none;
     background: transparent;
@@ -28,15 +28,19 @@ code-example pre {
     margin: 0 1em 0 0;
     padding: 0 0.65em 0.4em 0.65em;
   }
-  
+
   .language-switcher--setter:not(.selected):hover {
     color: $s-color-neutral3;
     border-bottom: 3px solid $s-color-neutral3;
   }
-  
+
   .language-switcher--setter.selected {
     border-bottom: 3px solid $s-color-primary4;
     color: $s-color-primary4;
   }
 }
 
+.drop-element .symbol-description {
+  max-height: 10.5em;
+  overflow: hidden;
+}

--- a/src/styles/_footnotes.scss
+++ b/src/styles/_footnotes.scss
@@ -1,6 +1,3 @@
-// Note Drop also provides SASS content we could use for more customization.
-@import '../../bower_components/tether-drop/dist/css/drop-theme-arrows.min';
-
 // Line separating footnotes from rest of document
 .footnotes-sep {
   border: none;
@@ -8,35 +5,4 @@
   // like most text content, .footnotes-sep has a max-width. However, it is
   // normally centered. Remove the left margin so it lines up with content.
   margin-left: 0;
-}
-
-// Popover for displaying footnotes in context
-.drop-element.footnote-drop {
-  $background-color: whiten($s-color-neutral8, 50%);
-  opacity: 0;
-
-  &.drop-after-open {
-    transition: opacity 0.25s;
-    opacity: 1;
-  }
-
-  // Set the color of the "arrow" in the popover
-  &.drop-element-attached-bottom.drop-element-attached-center .drop-content:before {
-    border-top-color: $background-color;
-  }
-  &.drop-element-attached-top.drop-element-attached-center .drop-content:before {
-    border-bottom-color: $background-color;
-  }
-
-  .drop-content {
-    background: $background-color;
-    max-width: 30em;
-    filter:
-      drop-shadow(0 0px 1px $s-color-neutral5)
-      drop-shadow(0 1px 8px rgba(0, 0, 0, 0.2));
-
-    p:last-child {
-      margin-bottom: 0;
-    }
-  }
 }

--- a/src/styles/_popovers.scss
+++ b/src/styles/_popovers.scss
@@ -1,0 +1,37 @@
+// Note Drop also provides SASS content we could use for more customization.
+@import '../../bower_components/tether-drop/dist/css/drop-theme-arrows.min';
+
+// Customized version of Drop's built-in 'drop-theme-arrows' theme
+.drop-element.drop-theme-arrows {
+  $background-color: whiten($s-color-neutral8, 50%);
+  opacity: 0;
+
+  &.drop-after-open {
+    transition: opacity 0.25s;
+    opacity: 1;
+  }
+
+  // Set the color of the "arrow" in the popover
+  &.drop-element-attached-bottom.drop-element-attached-center .drop-content:before {
+    border-top-color: $background-color;
+  }
+  &.drop-element-attached-top.drop-element-attached-center .drop-content:before {
+    border-bottom-color: $background-color;
+  }
+
+  .drop-content {
+    background: $background-color;
+    max-width: 30em;
+    filter:
+      drop-shadow(0 0px 1px $s-color-neutral5)
+      drop-shadow(0 1px 8px rgba(0, 0, 0, 0.2));
+
+    p:last-child {
+      margin-bottom: 0;
+    }
+
+    s-read-md {
+      display: block;
+    }
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -6,6 +6,7 @@
 @import 'solar-stellarorg/styles/index';
 @import 'solar-stellarorg-pages/styles/index';
 
+@import 'popovers';
 @import 'friendbot4';
 @import 'mailSignup';
 @import 'graphics';


### PR DESCRIPTION
This adds reference information about symbols in the code samples as popovers (with additional links to the actual reference docs:

![screen shot 2016-10-07 at 4 17 51 pm](https://cloud.githubusercontent.com/assets/74178/19208496/7c08d586-8caf-11e6-8cab-9ece4f8a2bb7.png)

At the moment, it only works for JS. The process is twofold:

1. At build time, we generate a JSON file with summarized documentation (names of symbols, a shortened description, and URLs for documentation of those symbols). This lives in the developers repo right now, but _maybe_ would be better in each SDK repo. Not sure.

2. At runtime, we load the JSON in via XHR and do a pretty naive search for matching symbol names. Since we control the samples, we can make sure we don't wind up with false matches, but a more advanced system that knows how to analyze different types of source code could do a better job at build time. I think this current system good enough for most cases and dramatically less effort, though.

This also turns URLs in comments in code samples into links (for all languages, not just JS):

![screen shot 2016-10-07 at 4 38 58 pm](https://cloud.githubusercontent.com/assets/74178/19208513/c228f4a6-8caf-11e6-8709-4bc1f17c0a4e.png)

Anyway, this works, but I'm not sure if it's nice enough. Up to other people whether it's mergeable or needs more work first.