### PR TITLE
reroute to services/horizon/internal where needed, closes #89

### DIFF
--- a/gulp/enhance.js
+++ b/gulp/enhance.js
@@ -115,7 +115,7 @@ function addDefaultTitles(file, filePath) {
 }
 
 function addExamples(f, p, metalsmith) {
-  if(!minimatch(p, "go/services/horizon/reference/*.*")) return;
+  if(!minimatch(p, "go/services/horizon/internal/reference/*.*")) return;
   let examples = metalsmith.metadata()._examples;
   let ext = path.extname(p);
   let endpoint = path.basename(p).slice(0,-ext.length);

--- a/partials/reference/sidebar.handlebars
+++ b/partials/reference/sidebar.handlebars
@@ -3,12 +3,12 @@
     <ul class="pageNavList">
 
       {{#sidebarSubMenu "REST API" collapsible=true}}
-        {{>sidebarSubItems glob="go/services/horizon/reference/index.html"}}
-        {{>sidebarSubItems glob="go/services/horizon/reference/!(index).html"}}
-        {{>sidebarSubMenu title="Tutorials" glob="go/services/horizon/reference/tutorials/*.html"}}
-        {{>sidebarSubMenu title="Endpoints" glob="go/services/horizon/reference/endpoints/*.html"}}
-        {{>sidebarSubMenu title="Resources" glob="go/services/horizon/reference/resources/*.html"}}
-        {{>sidebarSubMenu title="Errors" glob="go/services/horizon/reference/errors/*.html"}}
+        {{>sidebarSubItems glob="go/services/horizon/internal/reference/index.html"}}
+        {{>sidebarSubItems glob="go/services/horizon/internal/reference/!(index).html"}}
+        {{>sidebarSubMenu title="Tutorials" glob="go/services/horizon/internal/reference/tutorials/*.html"}}
+        {{>sidebarSubMenu title="Endpoints" glob="go/services/horizon/internal/reference/endpoints/*.html"}}
+        {{>sidebarSubMenu title="Resources" glob="go/services/horizon/internal/reference/resources/*.html"}}
+        {{>sidebarSubMenu title="Errors" glob="go/services/horizon/internal/reference/errors/*.html"}}
       {{/sidebarSubMenu}}
 
       {{#sidebarSubMenu "JavaScript SDK" collapsible=true}}

--- a/src/horizon
+++ b/src/horizon
@@ -1,1 +1,1 @@
-../repos/go/services/horizon/docs
+../repos/go/services/horizon/internal/docs

--- a/src/index.handlebars
+++ b/src/index.handlebars
@@ -52,7 +52,7 @@ previewImage: landing-2.png
         <h2 class="spu-color-neutral4 landing0616-resTitle">Reference &amp; SDKs</h2>
       </div>
       <ul class="spu-color-primary4 landing0616-res">
-        <li class="landing0616-res__item"><a href="https://github.com/stellar/go/tree/master/services/horizon/reference/">REST API</a></li>
+        <li class="landing0616-res__item"><a href="https://github.com/stellar/go/tree/master/services/horizon/internal/reference/">REST API</a></li>
         <li class="landing0616-res__item"><a href="{{pathPrefix}}/js-stellar-sdk/reference/">JavaScript SDK</a></li>
         <li class="landing0616-res__item"><a href="https://github.com/stellar/java-stellar-sdk">Java SDK</a></li>
         <li class="landing0616-res__item"><a href="https://github.com/stellar/go-stellar-base">Go SDK</a></li>


### PR DESCRIPTION
fixed all horizon references, changing to services/horizon/internal where needed.
fixed symlink as well.