### PR TITLE
Fix Go SDK Link on developers landing page

### DIFF
--- a/src/index.handlebars
+++ b/src/index.handlebars
@@ -55,7 +55,7 @@ previewImage: landing-2.png
         <li class="landing0616-res__item"><a href="{{pathPrefix}}/horizon/reference/index.html">REST API</a></li>
         <li class="landing0616-res__item"><a href="{{pathPrefix}}/js-stellar-sdk/reference/">JavaScript SDK</a></li>
         <li class="landing0616-res__item"><a href="https://github.com/stellar/java-stellar-sdk">Java SDK</a></li>
-        <li class="landing0616-res__item"><a href="https://github.com/stellar/go-stellar-base">Go SDK</a></li>
+        <li class="landing0616-res__item"><a href="https://github.com/stellar/go">Go SDK</a></li>
         <li class="landing0616-res__item"><a href="https://github.com/elucidsoft/dotnetcore-stellar-sdk">C# .NET Core 2.0</a></li>
         <li class="landing0616-res__item"><a href="https://github.com/QuantozTechnology/csharp-stellar-base">C# SDK</a></li>
         <li class="landing0616-res__item"><a href="https://github.com/stellar/ruby-stellar-sdk">Ruby SDK</a></li>


### PR DESCRIPTION
Update Go SDK link to non-deprecated repository