### PR TITLE
Fix link to github for horizon reference

### DIFF
--- a/gulp/enhance.js
+++ b/gulp/enhance.js
@@ -36,6 +36,10 @@ function addRepoInfo(file, filePath) {
       file.repo = "docs";
       file.repoPath = filePath;
       break;
+    case "horizon":
+      file.repo = "go";
+      file.repoPath = "services/horizon/internal/docs/" + parts.slice(1).join("/");
+      break;
     default:
       // if parts[0] is the name of a repo, use it
       if (parts[0] in repos) {


### PR DESCRIPTION
Hello!

Currently "Edit this doc in GitHub" link is broken for Horizon docs (basically, all `horizon/reference/*` pages, e.g., https://www.stellar.org/developers/horizon/reference/endpoints/assets-all.html)

This PR fixes it