### PR TITLE
Separate official SDKs from community maintained

### DIFF
--- a/partials/reference/sidebar.handlebars
+++ b/partials/reference/sidebar.handlebars
@@ -29,7 +29,7 @@
 
       <li class="pageNavList__item"><a href="https://github.com/stellar/java-stellar-sdk" target="_blank" rel="noopener noreferrer">Java SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
 
-      {{#sidebarSubMenu "Community maintained SDKs" collapsible=true}}
+      {{#sidebarSubMenu "Community maintained SDKs"}}
         <li class="pageNavList__item"><a href="https://github.com/StellarCN/py-stellar-base" target="_blank" rel="noopener noreferrer">Python SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
         <li class="pageNavList__item"><a href="https://github.com/elucidsoft/dotnetcore-stellar-sdk" target="_blank" rel="noopener noreferrer">C# .NET Core 2.0 SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
         <li class="pageNavList__item"><a href="https://github.com/bnogalm/StellarQtSDK" target="_blank" rel="noopener noreferrer">C++ SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>

--- a/partials/reference/sidebar.handlebars
+++ b/partials/reference/sidebar.handlebars
@@ -28,12 +28,15 @@
       {{! e.g. >sidebarSubItems glob="java-stellar-sdk/guides/index.html"}}
 
       <li class="pageNavList__item"><a href="https://github.com/stellar/java-stellar-sdk" target="_blank" rel="noopener noreferrer">Java SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
-      <li class="pageNavList__item"><a href="https://github.com/StellarCN/py-stellar-base" target="_blank" rel="noopener noreferrer">Python SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
-      <li class="pageNavList__item"><a href="https://github.com/elucidsoft/dotnetcore-stellar-sdk" target="_blank" rel="noopener noreferrer">C# .NET Core 2.0 SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
-      <li class="pageNavList__item"><a href="https://github.com/bnogalm/StellarQtSDK" target="_blank" rel="noopener noreferrer">C++ SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
-      <li class="pageNavList__item"><a href="https://github.com/Synesso/scala-stellar-sdk" target="_blank" rel="noopener noreferrer">Scala SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
-      <li class="pageNavList__item"><a href="https://github.com/bloom-solutions/ruby-stellar-sdk" target="_blank" rel="noopener noreferrer">Ruby SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
-      <li class="pageNavList__item"><a href="https://github.com/Soneso/stellar-ios-mac-sdk" target="_blank" rel="noopener noreferrer">iOS & macOS <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
+
+      {{#sidebarSubMenu "Community maintained SDKs" collapsible=true}}
+        <li class="pageNavList__item"><a href="https://github.com/StellarCN/py-stellar-base" target="_blank" rel="noopener noreferrer">Python SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
+        <li class="pageNavList__item"><a href="https://github.com/elucidsoft/dotnetcore-stellar-sdk" target="_blank" rel="noopener noreferrer">C# .NET Core 2.0 SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
+        <li class="pageNavList__item"><a href="https://github.com/bnogalm/StellarQtSDK" target="_blank" rel="noopener noreferrer">C++ SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
+        <li class="pageNavList__item"><a href="https://github.com/Synesso/scala-stellar-sdk" target="_blank" rel="noopener noreferrer">Scala SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
+        <li class="pageNavList__item"><a href="https://github.com/bloom-solutions/ruby-stellar-sdk" target="_blank" rel="noopener noreferrer">Ruby SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
+        <li class="pageNavList__item"><a href="https://github.com/Soneso/stellar-ios-mac-sdk" target="_blank" rel="noopener noreferrer">iOS & macOS <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
+      {{/sidebarSubMenu}}
 
     </ul>
   </div>

--- a/partials/reference/sidebar.handlebars
+++ b/partials/reference/sidebar.handlebars
@@ -29,7 +29,7 @@
 
       <li class="pageNavList__item"><a href="https://github.com/stellar/java-stellar-sdk" target="_blank" rel="noopener noreferrer">Java SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
 
-      {{#sidebarSubMenu "Community maintained SDKs"}}
+      {{#sidebarSubMenu "Community SDKs"}}
         <li class="pageNavList__item"><a href="https://github.com/StellarCN/py-stellar-base" target="_blank" rel="noopener noreferrer">Python SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
         <li class="pageNavList__item"><a href="https://github.com/elucidsoft/dotnetcore-stellar-sdk" target="_blank" rel="noopener noreferrer">C# .NET Core 2.0 SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
         <li class="pageNavList__item"><a href="https://github.com/bnogalm/StellarQtSDK" target="_blank" rel="noopener noreferrer">C++ SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>

--- a/partials/reference/sidebar.handlebars
+++ b/partials/reference/sidebar.handlebars
@@ -30,12 +30,12 @@
       <li class="pageNavList__item"><a href="https://github.com/stellar/java-stellar-sdk" target="_blank" rel="noopener noreferrer">Java SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
 
       {{#sidebarSubMenu "Community SDKs"}}
-        <li class="pageNavList__item"><a href="https://github.com/StellarCN/py-stellar-base" target="_blank" rel="noopener noreferrer">Python SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
-        <li class="pageNavList__item"><a href="https://github.com/elucidsoft/dotnetcore-stellar-sdk" target="_blank" rel="noopener noreferrer">C# .NET Core 2.0 SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
-        <li class="pageNavList__item"><a href="https://github.com/bnogalm/StellarQtSDK" target="_blank" rel="noopener noreferrer">C++ SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
-        <li class="pageNavList__item"><a href="https://github.com/Synesso/scala-stellar-sdk" target="_blank" rel="noopener noreferrer">Scala SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
-        <li class="pageNavList__item"><a href="https://github.com/bloom-solutions/ruby-stellar-sdk" target="_blank" rel="noopener noreferrer">Ruby SDK <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
-        <li class="pageNavList__item"><a href="https://github.com/Soneso/stellar-ios-mac-sdk" target="_blank" rel="noopener noreferrer">iOS & macOS <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
+        <li class="pageNavList__item"><a href="https://github.com/StellarCN/py-stellar-base" target="_blank" rel="noopener noreferrer">Python<span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
+        <li class="pageNavList__item"><a href="https://github.com/elucidsoft/dotnetcore-stellar-sdk" target="_blank" rel="noopener noreferrer">C# .NET Core 2.0<span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
+        <li class="pageNavList__item"><a href="https://github.com/bnogalm/StellarQtSDK" target="_blank" rel="noopener noreferrer">C++<span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
+        <li class="pageNavList__item"><a href="https://github.com/Synesso/scala-stellar-sdk" target="_blank" rel="noopener noreferrer">Scala<span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
+        <li class="pageNavList__item"><a href="https://github.com/bloom-solutions/ruby-stellar-sdk" target="_blank" rel="noopener noreferrer">Ruby<span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
+        <li class="pageNavList__item"><a href="https://github.com/Soneso/stellar-ios-mac-sdk" target="_blank" rel="noopener noreferrer">iOS & macOS<span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
       {{/sidebarSubMenu}}
 
     </ul>


### PR DESCRIPTION
Adds a heading to distinguish official SDKs from community SDKs. 

I waffled on what to do with the Java SDK. Considered whether to add an "official SDKs" section, add a section similar to Go and JS's SDKs, or just leave it top level. Left it top level for a minimal change, but it might warrant a bit more love.