### PR TITLE
link to SDK docs from sidebar

### DIFF
--- a/partials/reference/sidebar.handlebars
+++ b/partials/reference/sidebar.handlebars
@@ -22,7 +22,6 @@
         {{>sidebarSubItems glob="go/reference/index.html"}}
         {{>sidebarSubItems glob="go/reference/!(index).html"}}
         <li class="pageNavList__item"><a href="https://godoc.org/github.com/stellar/go/clients/horizonclient" target="_blank">Godoc (client) <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></li>
-      {{/sidebarSubMenu}}
         <li class="pageNavList__item"><a href="https://godoc.org/github.com/stellar/go/txnbuild" target="_blank">Godoc (tx builder) <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></li>
       {{/sidebarSubMenu}}
 

--- a/partials/reference/sidebar.handlebars
+++ b/partials/reference/sidebar.handlebars
@@ -21,7 +21,9 @@
       {{#sidebarSubMenu "Go SDK" collapsible=true}}
         {{>sidebarSubItems glob="go/reference/index.html"}}
         {{>sidebarSubItems glob="go/reference/!(index).html"}}
-        <li class="pageNavList__item"><a href="https://godoc.org/github.com/stellar/go" target="_blank">Godoc <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></li>
+        <li class="pageNavList__item"><a href="https://godoc.org/github.com/stellar/go/clients/horizonclient" target="_blank">Godoc (client) <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></li>
+      {{/sidebarSubMenu}}
+        <li class="pageNavList__item"><a href="https://godoc.org/github.com/stellar/go/txnbuild" target="_blank">Godoc (tx builder) <span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></li>
       {{/sidebarSubMenu}}
 
       {{! FIXME: these should be info pages rather than raw links to Github }}


### PR DESCRIPTION
Changes the sidebar link to point at the GoDocs for `horizonclient` and `txnbuild`, rather than the top of the monorepo.