### PR TITLE
Bring SDKs on home page up to date with sidebar.

### DIFF
--- a/partials/reference/sidebar.handlebars
+++ b/partials/reference/sidebar.handlebars
@@ -33,10 +33,10 @@
       {{#sidebarSubMenu "Community SDKs"}}
         <li class="pageNavList__item"><a href="https://github.com/StellarCN/py-stellar-base" target="_blank" rel="noopener noreferrer">Python<span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
         <li class="pageNavList__item"><a href="https://github.com/elucidsoft/dotnetcore-stellar-sdk" target="_blank" rel="noopener noreferrer">C# .NET Core 2.0<span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
-        <li class="pageNavList__item"><a href="https://github.com/bnogalm/StellarQtSDK" target="_blank" rel="noopener noreferrer">C++<span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
-        <li class="pageNavList__item"><a href="https://github.com/Synesso/scala-stellar-sdk" target="_blank" rel="noopener noreferrer">Scala<span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
         <li class="pageNavList__item"><a href="https://github.com/bloom-solutions/ruby-stellar-sdk" target="_blank" rel="noopener noreferrer">Ruby<span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
         <li class="pageNavList__item"><a href="https://github.com/Soneso/stellar-ios-mac-sdk" target="_blank" rel="noopener noreferrer">iOS & macOS<span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
+        <li class="pageNavList__item"><a href="https://github.com/Synesso/scala-stellar-sdk" target="_blank" rel="noopener noreferrer">Scala<span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
+        <li class="pageNavList__item"><a href="https://github.com/bnogalm/StellarQtSDK" target="_blank" rel="noopener noreferrer">C++<span class="icon-faSvg icon-faSvg--small icon-faSvg-external-neutral5"></span></a></a></li>
       {{/sidebarSubMenu}}
 
     </ul>

--- a/src/index.handlebars
+++ b/src/index.handlebars
@@ -52,21 +52,21 @@ previewImage: landing-2.png
         <h2 class="spu-color-neutral4 landing0616-resTitle">Reference &amp; SDKs</h2>
       </div>
       <ul class="spu-color-primary4 landing0616-res">
-        <li class="landing0616-res__item"><a href="{{pathPrefix}}/horizon/reference/index.html">REST API</a></li>
+        <li class="landing0616-res__item"><a href="{{pathPrefix}}/horizon/reference/">REST API</a></li>
         <li class="landing0616-res__item"><a href="{{pathPrefix}}/js-stellar-sdk/reference/">JavaScript SDK</a></li>
+        <li class="landing0616-res__item"><a href="{{pathPrefix}}/go/reference/">Go SDK</a></li>
         <li class="landing0616-res__item"><a href="https://github.com/stellar/java-stellar-sdk">Java SDK</a></li>
-        <li class="landing0616-res__item"><a href="https://github.com/stellar/go">Go SDK</a></li>
       </ul>
       <div class="landing0616-resLink">
-        <h2 class="spu-color-neutral4 landing0616-resTitle sub">Community maintained SDKs</h2>
+        <h2 class="spu-color-neutral4 landing0616-resTitle sub">Community SDKs</h2>
       </div>
       <ul class="spu-color-primary4 landing0616-res">
-        <li class="landing0616-res__item"><a href="https://github.com/elucidsoft/dotnetcore-stellar-sdk">C# .NET Core 2.0</a></li>
-        <li class="landing0616-res__item"><a href="https://github.com/bnogalm/StellarQtSDK">C++ SDK</a></li>
-        <li class="landing0616-res__item"><a href="https://github.com/stellar/ruby-stellar-sdk">Ruby SDK</a></li>
         <li class="landing0616-res__item"><a href="https://github.com/StellarCN/py-stellar-base">Python SDK</a></li>
-        <li class="landing0616-res__item"><a href="https://github.com/synesso/scala-stellar-sdk">Scala SDK</a></li>
+        <li class="landing0616-res__item"><a href="https://github.com/elucidsoft/dotnetcore-stellar-sdk">C# .NET Core 2.0 SDK</a></li>
+        <li class="landing0616-res__item"><a href="https://github.com/bloom-solutions/ruby-stellar-sdk">Ruby SDK</a></li>
         <li class="landing0616-res__item"><a href="https://github.com/Soneso/stellar-ios-mac-sdk">iOS and macOS SDK</a></li>
+        <li class="landing0616-res__item"><a href="https://github.com/synesso/scala-stellar-sdk">Scala SDK</a></li>
+        <li class="landing0616-res__item"><a href="https://github.com/bnogalm/StellarQtSDK">C++ SDK</a></li>
       </ul>
     </section>
 


### PR DESCRIPTION
Did a bit of reordering, fixed the Ruby link, and cleaned up the home page to look closer to the sidebar. Tested on a local build and it looks good to go by me (links all work as well).