### PR TITLE
Remove anchor guides sidebar and homepage link.

### DIFF
--- a/partials/guides/sidebar.handlebars
+++ b/partials/guides/sidebar.handlebars
@@ -6,12 +6,6 @@
         {{>sidebarSubItems glob="guides/get-started/!(index).html"}}
       {{/sidebarSubMenu}}
 
-
-      {{#sidebarSubMenu "Become an Anchor" numbered="true" }}
-        {{>sidebarSubItems glob="guides/anchor/index.html"}}
-        {{>sidebarSubItems glob="guides/anchor/!(index).html"}}
-      {{/sidebarSubMenu}}
-
       {{>sidebarSubMenu title="Concepts" glob="guides/concepts/*.html"}}
 
       {{>sidebarSubMenu title="Walkthroughs" glob="guides/walkthroughs/*.html"}}

--- a/src/index.handlebars
+++ b/src/index.handlebars
@@ -79,7 +79,6 @@ previewImage: landing-2.png
       </div>
       <ul class="spu-color-primary4 landing0616-res">
         <li class="landing0616-res__item"><a href="{{pathPrefix}}/guides/get-started/">Get Started</a></li>
-        <li class="landing0616-res__item"><a href="{{pathPrefix}}/guides/anchor/">Become an Anchor</a></li>
         <li class="landing0616-res__item"><a href="https://www.stellar.org/wp-content/uploads/2016/08/Sending-Payment-Flow-Detailed.jpg">Sending Payments</a></li>
         <li class="landing0616-res__item"><a href="https://www.stellar.org/wp-content/uploads/2016/08/Receiving-Payment-Flow-Detailed.jpg">Receiving Payments</a></li>
         <li class="landing0616-res__item"><a href="{{pathPrefix}}/guides/walkthroughs/stellar-smart-contracts.html">Stellar Smart Contracts (SSCs)</a></li>


### PR DESCRIPTION
Until the guides have been thoroughly revamped, remove them from the
website.