### PR TITLE
Build docs with gulp before generating code symbols.

### DIFF
--- a/gulp/code-symbol-tags.js
+++ b/gulp/code-symbol-tags.js
@@ -18,6 +18,7 @@ export function javascriptSymbols(callback) {
 
   // npm install in js-stellar-sdk
   child_process.spawnSync('yarn', ['install'], {cwd: './repos/js-stellar-sdk/'});
+  child_process.spawnSync('yarn', ['build:docs'], {cwd: './repos/js-stellar-sdk/'});
 
   const jsDoc = child_process.spawn(
     // Executed in './repos/js-stellar-sdk/'


### PR DESCRIPTION
Fixes https://github.com/stellar/developers/issues/117 - the reason for the broken build was that the command `/node_modules/.bin/jsdoc -c .jsdoc.json --explain` relied on `libdocs` existing. But it only gets created after running `yarn build:docs`.

It used to work because the `jsdoc.config` file was using the `src` directory, but with the move to TypeScript, we need to use `libdocs` which contains the transpiled source code - [see this change](https://github.com/stellar/js-stellar-sdk/commit/bf3b62ec3ba2bbeca9c6659bff572e518b9c62b9#diff-4c4e0bb5af5bd36c5762fb0883ef0752R3).

Depends on https://github.com/stellar/js-stellar-sdk/pull/380