### PR TITLE
Fix jenkins build

### DIFF
--- a/jenkins.bash
+++ b/jenkins.bash
@@ -16,7 +16,7 @@ cat <<-EOS > build-node.bash
 
   trap rollback INT TERM EXIT ERR
 
-  npm install -q -g gulp yarn
+  npm install -q -g gulp
 
   yarn install
   chown -R ${UID} ./node_modules


### PR DESCRIPTION
Yarn is included in the image so we can't install explicitly any more