### PR TITLE
Fix relative links, remove some analytics

### DIFF
--- a/partials/head.handlebars
+++ b/partials/head.handlebars
@@ -73,5 +73,17 @@
   a.src=document.location.protocol+"//script.crazyegg.com/pages/scripts/0065/1320.js?"+Math.floor(new Date().getTime()/3600000);
   a.async=true;a.type="text/javascript";b.parentNode.insertBefore(a,b)}, 1);
   </script>
+
+  <script type="text/javascript">
+  {{!--
+  If the url doesn't have a `.` (e.g. `.html`) and doesn't end with a slash, force a slash. Some links assume relative location and only work with a trailing slash.
+  --}}
+    if (
+      !/\./.test(location.pathname) &&
+      location.pathname[location.pathname.length - 1] !== '/'
+    ) {
+      history.replaceState(null, null, `${location.pathname}/`)
+    }
+  </script>
 </head>
 <body>

--- a/partials/head.handlebars
+++ b/partials/head.handlebars
@@ -68,13 +68,6 @@
   {{#frontmatterClientDataScript}}{{/frontmatterClientDataScript}}
 
   <script type="text/javascript">
-  setTimeout(function(){var a=document.createElement("script");
-  var b=document.getElementsByTagName("script")[0];
-  a.src=document.location.protocol+"//script.crazyegg.com/pages/scripts/0065/1320.js?"+Math.floor(new Date().getTime()/3600000);
-  a.async=true;a.type="text/javascript";b.parentNode.insertBefore(a,b)}, 1);
-  </script>
-
-  <script type="text/javascript">
   {{!--
   If the url doesn't have a `.` (e.g. `.html`) and doesn't end with a slash, force a slash. Some links assume relative location and only work with a trailing slash.
   --}}


### PR DESCRIPTION
stellar/docs#504 highlighted that _sometimes_ the "next page" link on docs are 404'ing. I dug a little and realized it's only when the URL is missing a trailing slash, because it expects a relative path. A few lines of JS will force it to always have a trailing slash.

The analytics aren't being used for any specific reason, so I'm removing them.