### PR TITLE
Add fixed link to JS symbols.

### DIFF
--- a/src/js/codeSymbolLinks.js
+++ b/src/js/codeSymbolLinks.js
@@ -8,7 +8,7 @@
   function loadSymbols() {
     return $.ajax({
       // FIXME: need to grab a base url from somewhere
-      url: '/js/javascript-symbols.json',
+      url: 'https://www.stellar.org/developers/js/javascript-symbols.json',
       dataType: 'json'
     });
   }


### PR DESCRIPTION
I just discovered this feature and that it was broken. Using the symbols, there is some code in this library that extends the JS code snippets to display an inline box showing the documentation with the methods being used.  Let's use a fixed link since it's pretty hard to reason about the final directory hierarchy for this site ;( 



![ezgif com-video-to-gif](https://user-images.githubusercontent.com/21772/81625876-c583b080-93bf-11ea-8b0f-0ed2148280e7.gif)
