### PR TITLE
Serve from docker with `/developers` prefixed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+repos
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && apt-get install -y curl git make gcc g++ apt-transport-htt
 
 
 RUN npm install -q -g gulp && yarn install && rm -rf ./repos/ && \
-    gulp --pathPrevix="/"
+    gulp --pathPrefix="/developers"
 
 FROM nginx:1.17
 
-COPY --from=build /app/src/build/ /usr/share/nginx/html/
+COPY --from=build /app/src/build/ /usr/share/nginx/html/developers


### PR DESCRIPTION
While migrating off the old subdomain, I hit a snag because we present this content from `/developers/*` but it's technically built and served as expecting `/*`. Luckily there's an existing prefix logic we can tap into.