### PR TITLE
Make replacement content banner more visible

### DIFF
--- a/partials/contentWrapperStart.handlebars
+++ b/partials/contentWrapperStart.handlebars
@@ -7,11 +7,13 @@
   </div>
   <div class="S-flex-rowWrap spu-borderTop-1 spu-borderColor-neutral7">
     <div class="mainContent s-read-md--capped spu-padSE-30 spu-padTB-20">
-      {{#if replacement}}
-      Updated content is available in <a href="{{replacement}}">the new documentation</a>.
-      {{else}}
-      This page is deprecated, and will be removed once <a href="https://developers.stellar.org/docs">the new documentation</a> is stable.
-      {{/if}}
+      <div class="replacement-banner">
+        {{#if replacement}}
+        Updated content is available in <a href="{{replacement}}">the new documentation</a>.
+        {{else}}
+        This page is deprecated, and will be removed once <a href="https://developers.stellar.org/docs">the new documentation</a> is stable.
+        {{/if}}
+      </div>
     </div>
   </div>
   <div class="S-flex-rowWrap spu-borderTop-1 spu-borderColor-neutral7">

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -362,3 +362,10 @@ s-read-md{
     }
   }
 }
+
+.replacement-banner {
+  padding: .25rem .5rem .25rem .5rem;
+  background-color: #3E1BDB;
+  border-radius: .25rem;
+  color: #FFF;
+}


### PR DESCRIPTION
Before:
<img width="661" alt="Screen Shot 2020-07-21 at 12 55 17 PM" src="https://user-images.githubusercontent.com/1551487/88083850-89a06080-cb51-11ea-9a32-1905a3ded001.png">
After:
<img width="861" alt="Screen Shot 2020-07-21 at 12 55 03 PM" src="https://user-images.githubusercontent.com/1551487/88083849-8907ca00-cb51-11ea-83ec-7ddef58fb432.png">
